### PR TITLE
Fixes for config ImageFactory and ImageIIIF

### DIFF
--- a/src/ImageFactory.php
+++ b/src/ImageFactory.php
@@ -15,7 +15,7 @@ class ImageFactory
     protected $driver = 'gd';
 
 
-   public function __invoke(array $config = null)
+   public function __invoke(Config $config = null)
    {
         if (is_null($config)) {
            $config = new Config(__DIR__ . '/../config');

--- a/src/ImageIIIF.php
+++ b/src/ImageIIIF.php
@@ -61,9 +61,9 @@ class ImageIIIF
             'width' => $this->image->width(),
             'profile' => [
                 'http://iiif.io/api/image/2/level2.json', [
-                    'supports' => config('iiif.supports'),
-                    'qualities' => config('iiif.qualities'),
-                    'formats' => config('iiif.formats')
+                    'supports' => $this->config->get('supports'),
+                    'qualities' => $this->config->get('qualities'),
+                    'formats' => $this->config->get('formats')
                 ]
             ],
             'tiles'=> [


### PR DESCRIPTION
ImageFactory requires that the arugment be type `array`, but ImageIIIF expects type `Config`.

And then there's a case or three where ImageIIIF uses `config()` which is provided by Laravel.  This worked better for me.