### PR TITLE
Fixed case mismatch in `SupportedFormats` trait name

### DIFF
--- a/src/Traits/SupportedFormats.php
+++ b/src/Traits/SupportedFormats.php
@@ -2,7 +2,7 @@
 
 namespace Conlect\ImageIIIF\Traits;
 
-trait supportedFormats
+trait SupportedFormats
 {
     public function getSupportedFormats(string $driver)
     {


### PR DESCRIPTION
This fix an issue with composer class autoloader throwing the following exception :
```
Fatal error: During class fetch: Uncaught RuntimeException: Case mismatch between loaded and declared class names: "Conlect\ImageIIIF\Traits\SupportedFormats" vs "Conlect\ImageIIIF\Traits\supportedFormats".
```